### PR TITLE
fix bug in post-processing

### DIFF
--- a/mmdet3d/models/dense_heads/centerpoint_head.py
+++ b/mmdet3d/models/dense_heads/centerpoint_head.py
@@ -818,7 +818,7 @@ class CenterHead(BaseModule):
 
             if isinstance(nms_rescale_factor, list):
                 for cid in range(len(nms_rescale_factor)):
-                    box_preds[cls_labels == cid, 3:6] = box_preds[cls_labels == cid, 3:6] / nms_rescale_factor[cid]
+                    box_preds[top_labels == cid, 3:6] = box_preds[top_labels == cid, 3:6] / nms_rescale_factor[cid]
             else:
                 box_preds[:, 3:6] = box_preds[:, 3:6] / nms_rescale_factor
 


### PR DESCRIPTION
## Motivation
When I use a larger score_threshold, it reports an error:

`  File "/home/zichen/Documents/Project/MMLab/Temp/MyBEV/projects/mmdet3d_plugin/models/dense_heads/bev_centerpoint_head.py", line 821, in get_task_detections
    box_preds[cls_labels == cid, 3:6] = box_preds[cls_labels == cid, 3:6] / nms_rescale_factor[cid]
IndexError: The shape of the mask [117] at index 0 does not match the shape of the indexed tensor [6, 3] at index 0`

## Modification
I use top_labels instead of cls_labels.
