### PR TITLE
fix a possible divided-by-zero bug

### DIFF
--- a/mmdet3d/ops/iou3d/src/iou3d_kernel.cu
+++ b/mmdet3d/ops/iou3d/src/iou3d_kernel.cu
@@ -194,6 +194,8 @@ __device__ inline float box_overlap(const float *box_a, const float *box_b) {
     }
   }
 
+  if (!cnt) return 0.0;
+  
   // check corners
   for (int k = 0; k < 4; k++) {
     if (check_in_box2d(box_a, box_b_corners[k])) {


### PR DESCRIPTION
## Motivation
Since we have   
  poly_center.x /= cnt;
  poly_center.y /= cnt;
in iou3d_kernel.cu, we potentially face divided-by-zero issue when bboxes aren't intersecting with each other, as no intersection exists, cnt=0. (We do encounter such issue during experiments.)

## Modification
Add zero prevention for denominator. No changes at other places.

## BC-breaking (Optional)
Does the modification introduce changes that break the back-compatibility of the downstream repos?
No.

## Use cases (Optional)
If this PR introduces a new feature, it is better to list some use cases here, and update the documentation.
Higher stability for your scale-nms

## Checklist
The correctness is checked via experiments.
