### PR TITLE
[Occupancy] Add LoadOccGTFromFile func; Fix wrong occ pkl path

### DIFF
--- a/configs/bevdet_occ/bevdet-occ-r50-4d-stereo-24e.py
+++ b/configs/bevdet_occ/bevdet-occ-r50-4d-stereo-24e.py
@@ -209,14 +209,14 @@ share_data_config = dict(
 
 test_data_config = dict(
     pipeline=test_pipeline,
-    ann_file=data_root + 'bevdetv2-nuscenes-occ_infos_val.pkl')
+    ann_file=data_root + 'bevdetv2-nuscenes_infos_val.pkl')
 
 data = dict(
     samples_per_gpu=4,
     workers_per_gpu=4,
     train=dict(
         data_root=data_root,
-        ann_file=data_root + 'bevdetv2-nuscenes-occ_infos_train.pkl',
+        ann_file=data_root + 'bevdetv2-nuscenes_infos_train.pkl',
         pipeline=train_pipeline,
         classes=class_names,
         test_mode=False,

--- a/mmdet3d/datasets/pipelines/__init__.py
+++ b/mmdet3d/datasets/pipelines/__init__.py
@@ -7,7 +7,7 @@ from .loading import (LoadAnnotations3D, LoadAnnotationsBEVDepth,
                       LoadPointsFromDict, LoadPointsFromFile,
                       LoadPointsFromMultiSweeps, NormalizePointsColor,
                       PointSegClassMapping, PointToMultiViewDepth,
-                      PrepareImageInputs)
+                      PrepareImageInputs, LoadOccGTFromFile)
 from .test_time_aug import MultiScaleFlipAug3D
 # yapf: disable
 from .transforms_3d import (AffineResize, BackgroundPointsFilter,
@@ -33,5 +33,6 @@ __all__ = [
     'RandomJitterPoints', 'AffineResize', 'RandomShiftScale',
     'LoadPointsFromDict', 'MultiViewWrapper', 'RandomRotate',
     'RangeLimitedRandomCrop', 'PrepareImageInputs',
-    'LoadAnnotationsBEVDepth', 'PointToMultiViewDepth'
+    'LoadAnnotationsBEVDepth', 'PointToMultiViewDepth',
+    'LoadOccGTFromFile'
 ]

--- a/mmdet3d/datasets/pipelines/loading.py
+++ b/mmdet3d/datasets/pipelines/loading.py
@@ -1,4 +1,6 @@
 # Copyright (c) OpenMMLab. All rights reserved.
+import os
+
 import mmcv
 import numpy as np
 import torch
@@ -9,6 +11,24 @@ from mmdet3d.core.points import BasePoints, get_points_type
 from mmdet.datasets.pipelines import LoadAnnotations, LoadImageFromFile
 from ...core.bbox import LiDARInstance3DBoxes
 from ..builder import PIPELINES
+
+@PIPELINES.register_module()
+class LoadOccGTFromFile(object):
+    def __call__(self, results):
+        occ_gt_path = results['occ_gt_path']
+        occ_gt_path = os.path.join(occ_gt_path, "labels.npz")
+
+        occ_labels = np.load(occ_gt_path)
+        semantics = occ_labels['semantics']
+        mask_lidar = occ_labels['mask_lidar']
+        mask_camera = occ_labels['mask_camera']
+
+        results['voxel_semantics'] = semantics
+        results['mask_lidar'] = mask_lidar
+        results['mask_camera'] = mask_camera
+
+
+        return results
 
 
 @PIPELINES.register_module()


### PR DESCRIPTION
This PR adds the lost `LoadOccGTFromFile` function and also tries to fix wrong occ pkl path in occupancy config file. 
With this PR, the `bevdet-occ-stbase-4d-stereo-512x1408-24e.py` can be trained successfully.


`
2023-04-28 14:48:16,890 - mmdet - INFO - Epoch [1][50/1759]     lr: 4.915e-05, eta: 10 days, 12:42:55, time: 5.174, data_time: 0.198, memory: 15119, loss_depth: 0.2679, loss_occ: 2.6189, loss: 2.8868, grad_norm: 4.7577`


![image](https://user-images.githubusercontent.com/93700759/235179744-a0207f82-ec03-47e0-ad86-c675f8030f65.png)
